### PR TITLE
Added support for multiple `JacocoInstrumentationTask` tasks

### DIFF
--- a/plugin/src/main/kotlin/io/github/gmazzo/gradle/testkit/jacoco/JacocoGradleTestKitPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/gradle/testkit/jacoco/JacocoGradleTestKitPlugin.kt
@@ -2,18 +2,21 @@ package io.github.gmazzo.gradle.testkit.jacoco
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaPlugin.TEST_TASK_NAME
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.getValue
-import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.registering
 import org.gradle.kotlin.dsl.the
+import org.gradle.kotlin.dsl.withGroovyBuilder
+import org.gradle.kotlin.dsl.withType
 import org.gradle.plugin.devel.tasks.PluginUnderTestMetadata
 import org.gradle.testing.jacoco.plugins.JacocoPlugin.ANT_CONFIGURATION_NAME
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
+import java.io.File
 
 class JacocoGradleTestKitPlugin : Plugin<Project> {
 
@@ -21,7 +24,7 @@ class JacocoGradleTestKitPlugin : Plugin<Project> {
         apply(plugin = "java-gradle-plugin")
         apply(plugin = "jacoco")
 
-        val jacoco = the<JacocoPluginExtension>()
+        val jacoco: JacocoPluginExtension by extensions
 
         val jacocoRuntime by configurations.registering {
             defaultDependencies {
@@ -29,32 +32,47 @@ class JacocoGradleTestKitPlugin : Plugin<Project> {
             }
         }
 
-        val instrumentationTask =
-            tasks.register<JacocoInstrumentationTask>("instrumentPluginClassesForJaCoCo") {
-                jacocoClasspath.from(configurations.named(ANT_CONFIGURATION_NAME))
-                instrumentedClassesDir.convention(layout.buildDirectory.dir("jacoco/instrumented-classes"))
-            }
-
         val propertiesTask = tasks.register<JacocoAgentPropertiesTask>("generateJaCoCoAgentPropertiesForTestKit") {
             jacocoExecFile.set(tasks.getByName(TEST_TASK_NAME).the<JacocoTaskExtension>().destinationFile)
         }
 
         afterEvaluate {
-            tasks.named<PluginUnderTestMetadata>("pluginUnderTestMetadata") {
-                val it = instrumentationTask.get()
-                it.dependsOn(dependsOn)
-                it.classpath.from(pluginClasspath.from.toList())
+            tasks.withType<PluginUnderTestMetadata>().configureEach task@{
+                val original = files(pluginClasspath.from.toList())
+                val outputDir = layout.buildDirectory.dir("jacoco/instrumented-classes/${this@task.name}")
+
+                outputs.dir(outputDir)
 
                 pluginClasspath.setFrom(
-                    it.instrumentedClassesDir,
-                    it.classpath,
+                    outputDir.map { instrumentWithJacoco(original, it.asFile) } ,
+                    original, // for JAR or resources from the original classpath, the instrumented ones will take precedence
                     propertiesTask,
                     jacocoRuntime,
                     JacocoGradleTestKitPlugin::class.java.jarFile,
                 )
             }
         }
+    }
 
+    private fun Project.instrumentWithJacoco(from: FileCollection, into: File) = with(createAntBuilder()) {
+        invokeMethod(
+            "taskdef",
+            mapOf(
+                "name" to "instrument",
+                "classname" to "org.jacoco.ant.InstrumentTask",
+                "classpath" to configurations.getByName(ANT_CONFIGURATION_NAME).asPath,
+            )
+        )
+        withGroovyBuilder {
+            "instrument"("destdir" to into) {
+                from.forEach {
+                    if (it.isDirectory && !it.startsWith(into.parentFile)) {
+                        "fileset"("dir" to it, "includes" to "**/*.class")
+                    }
+                }
+            }
+        }
+        return@with into
     }
 
     private val Class<*>.jarFile

--- a/plugin/src/test/kotlin/io/github/gmazzo/gradle/testkit/jacoco/JacocoGradleTestKitPluginTest.kt
+++ b/plugin/src/test/kotlin/io/github/gmazzo/gradle/testkit/jacoco/JacocoGradleTestKitPluginTest.kt
@@ -50,7 +50,7 @@ class JacocoGradleTestKitPluginTest {
 
         assertEquals(
             listOf(
-                "$projectDir/build/jacoco/instrumented-classes",
+                "$projectDir/build/jacoco/instrumented-classes/pluginUnderTestMetadata",
                 "$projectDir/build/classes/java/main",
                 "$projectDir/build/resources/main",
                 "$tempDir/work/.gradle-test-kit/caches/modules-2/files-2.1/com.squareup/javapoet/1.13.0/d6562d385049f35eb50403fa86bb11cce76b866a/javapoet-1.13.0.jar",
@@ -66,9 +66,8 @@ class JacocoGradleTestKitPluginTest {
                 "org/test/myplugin/utils/UtilsImpl.class",
                 "org/test/myplugin/utils/Utils.class",
                 "org/test/myplugin/MyPlugin.class",
-                "META-INF/gradle-plugins/myPlugin.properties",
             ),
-            projectDir.resolve("build/jacoco/instrumented-classes").run root@{
+            projectDir.resolve("build/jacoco/instrumented-classes/pluginUnderTestMetadata").run root@{
                 walkTopDown().filter { it.isFile }.map { it.toRelativeString(this@root) }.toSet()
             })
 


### PR DESCRIPTION
Added `JacocoInstrumentationTask` tasks support, meant to integrate well with [`gradle-multiapi-dev-plugin`](https://github.com/gmazzo/gradle-multiapi-dev-plugin)